### PR TITLE
fix: rarity filter inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can also react with 💰 to get its drop data directly from Wakfu's website
 .equip martelo de osamodas lang=pt
 .equip brakmar sword translate=fr
 .equip the eternal rarity=mythical
+.equip o eterno raridade=mítico
 ```
 
 ![](https://i.imgur.com/0oZzZ4W.png)

--- a/src/commands/equip.js
+++ b/src/commands/equip.js
@@ -31,20 +31,29 @@ const iconCodeMap = {
  *
  * @param {object[]} equipmentList
  * @param {string} query
- * @param {string[]} filters
+ * @param {string[]} options
  * @param {string} lang
  * @returns {object[]}
  */
-function findEquipmentByName (equipmentList, query, filters, lang) {
-  const hasRarityFilter = Boolean(filters.rarity)
-  if (!hasRarityFilter) {
+function findEquipmentByName (equipmentList, query, options, lang) {
+  const hasRarityOption = Object.values(str.rarity).some(rarityWord => {
+    const optionsKeys = Object.keys(options)
+    return optionsKeys.some(optionsKey => {
+      return hasTextOrNormalizedTextIncluded(rarityWord, optionsKey)
+    })
+  })
+
+  if (!hasRarityOption) {
     return equipmentList.filter(equip => hasTextOrNormalizedTextIncluded(equip.title[lang], query))
   }
 
   return equipmentList.filter(equip => {
     let filterAssertion = true
     const includeQuery = hasTextOrNormalizedTextIncluded(equip.title[lang], query)
-    const hasRarity = rarityMap[equip.rarity].name[lang].toLowerCase().includes(filters.rarity)
+    const equipRarity = rarityMap[equip.rarity].name[lang].toLowerCase()
+    const hasRarity = Object.values(str.rarity).some(rarityWord => {
+      return hasTextOrNormalizedTextIncluded(rarityWord, equipRarity)
+    })
     filterAssertion = filterAssertion && hasRarity
 
     return includeQuery && filterAssertion

--- a/src/commands/equip.js
+++ b/src/commands/equip.js
@@ -2,7 +2,7 @@ import itemsData from '../../data/generated/items.json'
 import recipesData from '../../data/generated/recipes.json'
 import { mountCommandHelpEmbed } from './help'
 import { getArgumentsAndOptions, mountNotFoundEmbed, reactToMessage } from '../utils/message'
-import { setLanguage, isValidLang } from '../utils/language'
+import { setLanguage, isValidLang, getRarityIdByRarityNameInAnyLanguage } from '../utils/language'
 import { hasTextOrNormalizedTextIncluded } from '../utils/strings'
 import { mountUrl } from '../scrappers/drop'
 import str from '../stringsLang'
@@ -36,24 +36,20 @@ const iconCodeMap = {
  * @returns {object[]}
  */
 function findEquipmentByName (equipmentList, query, options, lang) {
-  const hasRarityOption = Object.values(str.rarity).some(rarityWord => {
-    const optionsKeys = Object.keys(options)
-    return optionsKeys.some(optionsKey => {
-      return hasTextOrNormalizedTextIncluded(rarityWord, optionsKey)
-    })
+  const optionsKeys = Object.keys(options)
+  const optionRarityKey = Object.values(str.rarity).find(rarityWord => {
+    return optionsKeys.some(optionsKey => hasTextOrNormalizedTextIncluded(rarityWord, optionsKey))
   })
 
-  if (!hasRarityOption) {
+  if (!optionRarityKey) {
     return equipmentList.filter(equip => hasTextOrNormalizedTextIncluded(equip.title[lang], query))
   }
 
   return equipmentList.filter(equip => {
     let filterAssertion = true
     const includeQuery = hasTextOrNormalizedTextIncluded(equip.title[lang], query)
-    const equipRarity = rarityMap[equip.rarity].name[lang].toLowerCase()
-    const hasRarity = Object.values(str.rarity).some(rarityWord => {
-      return hasTextOrNormalizedTextIncluded(rarityWord, equipRarity)
-    })
+    const rarityIdOption = getRarityIdByRarityNameInAnyLanguage(options[optionRarityKey])
+    const hasRarity = rarityIdOption === equip.rarity
     filterAssertion = filterAssertion && hasRarity
 
     return includeQuery && filterAssertion

--- a/src/utils/handleError.js
+++ b/src/utils/handleError.js
@@ -22,7 +22,7 @@ export function handleMessageError (error, message) {
   const channelName = message && message.channel && message.channel.name
   const authorName = message && message.author && message.author.username
   const errorText = error.toString() || ''
-  console.log(`${errorText} on guild "${guildName}", channel "${channelName}" by ${authorName}`)
+  console.log(`${errorText} on guild "${guildName}", channel "${channelName}" by ${authorName} with content \n${message.content}`)
   if (errorText.includes('TypeError')) {
     console.log(error)
   }

--- a/src/utils/helpMessages.js
+++ b/src/utils/helpMessages.js
@@ -118,7 +118,8 @@ Rejoignez et quittez n'importe quel groupe en y réagissant avec la classe de vo
     examples: [
       '.recipe brakmar sword',
       '.recipe espada de brakmar lang=pt',
-      '.recipe peace pipe rarity=mythical'
+      '.recipe peace pipe rarity=mythical',
+      '.recipe o eterno raridade=mítico lang=pt'
     ]
   },
   help: {

--- a/src/utils/language.js
+++ b/src/utils/language.js
@@ -1,4 +1,6 @@
 import { getConfig } from './message'
+import config from '../config'
+const { rarityMap } = config
 
 /**
  * Check if the provided language string is valid.
@@ -42,4 +44,18 @@ export function guessLanguage (text, strObject) {
     }
     return lang
   }, 'en')
+}
+
+/**
+ * Get the rarity number according to the name provided
+ * in any supported language.
+ *
+ * @param {string} rarityName
+ * @returns {number}
+ */
+export function getRarityIdByRarityNameInAnyLanguage (rarityName) {
+  return Object.entries(rarityMap).reduce((idDetected, [rarityId, rarityDetails]) => {
+    const names = Object.values(rarityDetails.name)
+    return names.some(name => rarityName.toLowerCase() === name.toLowerCase()) ? Number(rarityId) : idDetected
+  }, 0)
 }

--- a/tests/equip.test.js
+++ b/tests/equip.test.js
@@ -85,6 +85,17 @@ describe('getEquipment', () => {
     }]))
   })
 
+  it('return a matching equipment by name with lower rarity with rarity argument is provided on another language', async () => {
+    const content = '.equip o eterno raridade=mítico'
+    const userMessage = mockMessage(content)
+    const botMessage = await getEquipment(userMessage)
+    expect(botMessage.embed.fields).toEqual(expect.arrayContaining([{
+      name: 'Raridade',
+      value: 'Mítico',
+      inline: true
+    }]))
+  })
+
   it('return the condition if the resulting equipment has one', async () => {
     const content = '.equip amakna sword'
     const userMessage = mockMessage(content)

--- a/tests/equip.test.js
+++ b/tests/equip.test.js
@@ -74,7 +74,7 @@ describe('getEquipment', () => {
     expect(botMessage.embed.title).toEqual(':yellow_circle: Chapéu Lêmico')
   })
 
-  it('return a matching equipment by name with lower rarity with rarity argument is provided', async () => {
+  it('return a matching equipment by name and rarity with rarity argument is provided', async () => {
     const content = '.equip the eternal rarity=mythical'
     const userMessage = mockMessage(content)
     const botMessage = await getEquipment(userMessage)
@@ -85,10 +85,23 @@ describe('getEquipment', () => {
     }]))
   })
 
-  it('return a matching equipment by name with lower rarity with rarity argument is provided on another language', async () => {
-    const content = '.equip o eterno raridade=mítico'
+  it('return a matching equipment by name and rarity with rarity argument is provided on another language', async () => {
+    const content = '.equip o eterno raridade=mítico lang=pt'
     const userMessage = mockMessage(content)
     const botMessage = await getEquipment(userMessage)
+    expect(botMessage.embed.title).toEqual(':orange_circle: O Eterno')
+    expect(botMessage.embed.fields).toEqual(expect.arrayContaining([{
+      name: 'Raridade',
+      value: 'Mítico',
+      inline: true
+    }]))
+  })
+
+  it('return a matching equipment by name and rarity with rarity argument with mixed languages', async () => {
+    const content = '.equip o eterno raridade=mythical lang=pt'
+    const userMessage = mockMessage(content)
+    const botMessage = await getEquipment(userMessage)
+    expect(botMessage.embed.title).toEqual(':orange_circle: O Eterno')
     expect(botMessage.embed.fields).toEqual(expect.arrayContaining([{
       name: 'Raridade',
       value: 'Mítico',

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,5 +1,5 @@
 import { getArgumentsAndOptions, getCommand, setStartupConfig } from '../src/utils/message'
-import { setLanguage } from '../src/utils/language'
+import { setLanguage, getRarityIdByRarityNameInAnyLanguage } from '../src/utils/language'
 import findPermutations from '../src/utils/permutateString'
 import { handleMessageError, handleReactionError } from '../src/utils/handleError'
 import { mockMessage } from './testUtils'
@@ -97,5 +97,28 @@ describe('setStartupConfig', () => {
     const spy = jest.spyOn(global.console, 'log').mockImplementation()
     await setStartupConfig()
     expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe('getRarityIdByRarityNameInAnyLanguage', () => {
+  it('gets the rarity id by rarity name in portuguese', () => {
+    const rarityName = 'mítico'
+    const expectedId = 3
+    const rarityId = getRarityIdByRarityNameInAnyLanguage(rarityName)
+    expect(rarityId).toEqual(expectedId)
+  })
+
+  it('gets the rarity id by rarity name in french', () => {
+    const rarityName = 'légendaire'
+    const expectedId = 4
+    const rarityId = getRarityIdByRarityNameInAnyLanguage(rarityName)
+    expect(rarityId).toEqual(expectedId)
+  })
+
+  it('gets the rarity id 0 if no rarity name is matched', () => {
+    const rarityName = 'tratoska'
+    const expectedId = 0
+    const rarityId = getRarityIdByRarityNameInAnyLanguage(rarityName)
+    expect(rarityId).toEqual(expectedId)
   })
 })


### PR DESCRIPTION
We're fixing https://github.com/Markkop/corvo-astral/issues/19 in the way where the rarity keywords from every supported language will be matched, so any of the following combination should work:

```
.equip <name> rarity=mythical
.equip <name> raridade=mítico
.equip <name> rarity=mítico
.equip <name> raridade=mythical
.equip <name> raridade=mythical lang=en
.equip <name> raridade=mythical lang=pt
```
and so on