### PR TITLE
fix: monster id with numbers on name

### DIFF
--- a/src/scrappers/monster.js
+++ b/src/scrappers/monster.js
@@ -33,7 +33,8 @@ function scrapMonsterSearch () {
   return monsterResultsElements.map(element => {
     const nameElement = element.querySelector('td:nth-child(2) a')
     const name = nameElement.innerText
-    const id = nameElement.href.replace(/\D/g, '')
+    const idMatch = nameElement.href.match(/([0-9]+)/)
+    const id = idMatch[1]
     const familyElement = element.querySelector('td:nth-child(3)')
     const family = familyElement.innerText
     const levelElement = element.querySelector('td:nth-child(5)')


### PR DESCRIPTION
Monster that had a number in its name, such as [Korbot K-800](https://www.wakfu.com/pt/mmorpg/enciclopedia/monstros/3696-korbot-k-800) would make the monster scrapper to break,